### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,8 @@
 name: Deploy to GitHub Pages
 
+permissions:
+  contents: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/josefdc/page-replacement-simulator/security/code-scanning/1](https://github.com/josefdc/page-replacement-simulator/security/code-scanning/1)

To fix the problem, you should explicitly set a `permissions` block for your workflow, either at the root level (before `jobs:`) so it applies to all jobs, or at the individual job level. Since there's only one job (`build`), either location is fine, but it's preferable to set permissions at the root for clarity. The recommended minimum for deploying to GitHub Pages using `peaceiris/actions-gh-pages` is `contents: write`, which allows updating pages, while preventing unnecessary permissions for other resources.

Add the following block near the top of the workflow (between lines 2 and 3, just after the workflow name):

```yaml
permissions:
  contents: write
```

No imports, methods, or definitions are involved in a YAML workflow fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
